### PR TITLE
MAG-955: Optional YAML frontmatter in Markdown files; renders as tabl…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "twig/twig": "~1.24.0",
         "symfony/yaml": "~3.0.0",
         "chefkoch/display-patterns": "dev-master",
-        "michelf/php-markdown": "~1.6.0"
+        "michelf/php-markdown": "~1.6.0",
+        "kzykhys/yaml-front-matter": "^1.0"
     },
     "config": {
         "secure-http": false

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "0267f5125248788f5e559a15d2855b2c",
-    "content-hash": "c849a7ed8eb45a531ecb8ab3c0a90033",
+    "hash": "b0824a27e5d5a078b01c16425565821d",
+    "content-hash": "220000884a3c87b3f3547df9939f4096",
     "packages": [
         {
             "name": "chefkoch/display-patterns",
@@ -23,6 +23,48 @@
             },
             "type": "library",
             "time": "2016-05-03 08:26:58"
+        },
+        {
+            "name": "kzykhys/yaml-front-matter",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kzykhys/YamlFrontMatter.git",
+                "reference": "1f78c23564d8c3581502a1971f76148a9d0dd1e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kzykhys/YamlFrontMatter/zipball/1f78c23564d8c3581502a1971f76148a9d0dd1e5",
+                "reference": "1f78c23564d8c3581502a1971f76148a9d0dd1e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2",
+                "symfony/yaml": ">=2.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kazuyuki Hayashi",
+                    "email": "hayashi@valnur.net"
+                }
+            ],
+            "description": "YAML Front-matter Parser/Dumper for PHP",
+            "keywords": [
+                "front-matter",
+                "parser",
+                "yaml"
+            ],
+            "time": "2013-12-25 05:37:30"
         },
         {
             "name": "michelf/php-markdown",

--- a/html/content/_frontmatter.html.twig
+++ b/html/content/_frontmatter.html.twig
@@ -1,0 +1,16 @@
+<table class="frontmatter">
+    <thead>
+        <tr>
+            {% for key in frontmatter|keys %}
+                <th>{{ key }}</th>
+            {% endfor %}
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            {% for key, value in frontmatter %}
+                <td>{{ value|dump }}</td>
+            {% endfor %}
+        </tr>
+    </tbody>
+</table>

--- a/src/Model/MarkdownFile.php
+++ b/src/Model/MarkdownFile.php
@@ -3,6 +3,7 @@
 namespace Chefkoch\DisplayPatternLab\Model;
 
 use Michelf\Markdown;
+use KzykHys\FrontMatter\FrontMatter;
 
 class MarkdownFile extends File
 {
@@ -12,6 +13,17 @@ class MarkdownFile extends File
      */
     public function getHtml()
     {
-        return Markdown::defaultTransform($this->getContents());
+        $document = FrontMatter::parse($this->getContents());
+
+        $markup = '';
+        if ($document->getConfig()) {
+            $markup .= $GLOBALS['twig']->render(
+                '@lab/content/_frontmatter.html.twig',
+                [ 'frontmatter' => $document->getConfig() ]
+            );
+        }
+
+        $markup .= Markdown::defaultTransform($document->getContent());
+        return $markup;
     }
 }

--- a/src/generate.php
+++ b/src/generate.php
@@ -2,6 +2,8 @@
 
 require_once(__DIR__ . '/../vendor/autoload.php');
 
+use Symfony\Component\Yaml\Yaml;
+
 $config = json_decode($argv[1], true);
 
 $labTwigTemplatePath = realpath(__DIR__ . '/../html');
@@ -16,6 +18,11 @@ $indexFileName = basename($config['scss']['indexFile']);
 $cssFile = './css/' . str_replace('.scss', '.css', $indexFileName);
 
 $twig->addGlobal('displayPatternsCss', $cssFile);
+
+$filter = new Twig_SimpleFilter('dump', function ($string) {
+    return '<pre>' . trim(Yaml::dump($string, /*inline*/1, /*indent*/2)) . '</pre>';
+}, ['is_safe' => ['html']]);
+$twig->addFilter($filter);
 
 $factory = new \Chefkoch\DisplayPatternLab\Model\Factory();
 


### PR DESCRIPTION
- optional YAML frontmatter in Markdown files, using [kzykhys/yaml-front-matter](https://packagist.org/packages/kzykhys/yaml-front-matter)
- renders as table similar to Github, e.g. [this blog article](https://github.com/tinkerthon/tinkerthon.github.io/blob/master/_posts/2016-04-14-internet-buttons.md)
- nested levels dump as YAML
