### PR TITLE
MAG-957: Integrate http://sorgalla.com/lity/

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,6 +1,8 @@
 window.onload = adjustIframeHeight
 window.sizer = adjustIframeWidth
 
+require('lity')
+
 var $ = document.querySelectorAll
 
 function displayIframe(iFrame){

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "gulp-sass": "^2.1.1",
     "gulp-shell": "^0.5.2",
     "gulp-watch": "^4.3.5",
-    "interact.js": "^1.2.6"
+    "interact.js": "^1.2.6",
+    "jquery": "^2.2.3",
+    "lity": "^1.6.6"
   },
   "scripts": {
     "gulp": "node_modules/.bin/gulp"

--- a/scss/lab.scss
+++ b/scss/lab.scss
@@ -21,6 +21,7 @@ iframe {
   transition: 1s width linear;
 }
 
+@import "node_modules/lity/dist/lity";
 
 /*------------------------------------*\
   NAV


### PR DESCRIPTION
To be able to show images (scribbles, designs) inline in the documentation of a pattern, this patch integrates a lightweight lightbox http://sorgalla.com/lity/ . The integration uses `browserify` to require Lity javascript and an SCSS `import` for its stylesheet. 
